### PR TITLE
이미지가 없는 선택지의 경우는 카드 전체를 클릭 가능한 범위로 설정

### DIFF
--- a/src/routes/ChoiceInfo.tsx
+++ b/src/routes/ChoiceInfo.tsx
@@ -155,13 +155,11 @@ const ChoiceInfo = ({ userObj, isLoggedIn, onLogin }: ChoiceInfoProps) => {
     ) => {
         if (!isLoggedIn) return;
         if (isSelectFetching) return;
-        if (!choice1ImageButtonRef.current || !choice2ImageButtonRef.current)
-            return;
         if (
             (selectedChoice === CHOICE_1 &&
-                choice1ImageButtonRef.current.contains(event.target as Node)) ||
+                choice1ImageButtonRef.current?.contains(event.target as Node)) ||
             (selectedChoice === CHOICE_2 &&
-                choice2ImageButtonRef.current.contains(event.target as Node))
+                choice2ImageButtonRef.current?.contains(event.target as Node))
         )
             return;
         setSelectedChoice((prev) =>
@@ -453,6 +451,7 @@ const ChoiceInfo = ({ userObj, isLoggedIn, onLogin }: ChoiceInfoProps) => {
                                             <AspectRatio ratio={1}>
                                                 <Image
                                                     src={itemObj.choiceUrl}
+													draggable={false}
                                                 />
                                             </AspectRatio>
                                         )}


### PR DESCRIPTION
이미지가 없는 선택지의 경우도 고려하여 카드 전체를 클릭 가능하도록 하였습니다.
#21 